### PR TITLE
Fixed #31 - broken for parametrized build tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tscommand*
 tests/features/testdata/**
 tests/features/support/*.js
 .settings/*
+**/.tscache/**

--- a/src/lib/configs.ts
+++ b/src/lib/configs.ts
@@ -98,7 +98,7 @@ export class TaskRunnerConfigurationService {
         result.parent = parent;
         result.name = task;
         result.config = {};
-        result.config[currentStep.task] = currentStep;
+        result.config[currentStep.task.split(":")[0]] = currentStep;
         (<models.TaskRunner>result).task = currentStep.task;
         (<models.TaskRunner>result).package = currentStep.package;
         (<models.TaskRunner>result).dependencies = currentStep.dependencies;

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -6,6 +6,7 @@ var log = new logging.Log();
 export class TaskExecutionPrepareService {
     public static initTaskConfig(grunt, task, config): any {
         if (!config) throw "A task requires a configuration to run";
+        task = task.split(":")[0];
         delete config[task].task;
         delete config[task].package;
         delete config[task].dependencies;


### PR DESCRIPTION
Was broken for a the composer build task due to the attached parameter. The parameter is now removed when creating the config and sanitizing the task 